### PR TITLE
Added import * and __version__ in __init__.py

### DIFF
--- a/tdm_loader/__init__.py
+++ b/tdm_loader/__init__.py
@@ -1,0 +1,9 @@
+import os
+
+from .tdm_loader import *
+
+try:
+    with open(os.path.join(os.path.dirname(__file__), 'VERSION'), 'r') as fobj:
+        __version__ = fobj.read().strip()
+except IOError:
+    __version__ = 'unknown'


### PR DESCRIPTION
Added import * from tdm_loader.py, needed to use the following syntax in README:
import tdm_loader
data_file = tdm_loader.OpenFile('filename.tdm')
Also read __version__ from file, with read mode 'r', not 'rb'.