### PR TITLE
Read tdm file with utf-8 encoding

### DIFF
--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -561,7 +561,7 @@ class ReadTDM(object):
     """
     def __init__(self, tdm_path):
         try:
-            string = open(tdm_path, mode='r').read()
+            string = open(tdm_path, mode='r', encoding='utf-8').read()
         except IOError:
             raise IOError('TDM file not found: ' + tdm_path)
         self._xmltree = etree.XML(string)


### PR DESCRIPTION
With the default (platform-dependant) encoding I can't open my tdm files since there are unicode characters in them.
In case someone would need another encoding, we could add the keyword argument encoding='utf-8' to OpenFile and ReadTDM.