### PR TITLE
Fixed some issues with channel names

### DIFF
--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -653,8 +653,8 @@ class ReadTDM(object):
             blocks = temp.findall('block')
         channel_names = self._xmltree.find(QNAME + 'data').findall(
                                                                   'tdm_channel')
-        self.num_channels = len(blocks)
-        assert(len(blocks) == len(channel_names))
+        self.num_channels = len(channel_names)
+        assert(len(blocks) >= len(channel_names))
 
         formats = []
         names = []

--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -33,6 +33,7 @@ import re
 from xml.etree import cElementTree as etree
 import xml.etree.ElementTree as ElementTree
 from codecs import open
+import warnings
 
 import numpy as np
 try:
@@ -86,6 +87,10 @@ class OpenFile(object):
         self.channel_names = [chan.name for chan in self.tdm.channels]
         
         self._root = ElementTree.parse(tdm_path).getroot()
+        
+        self._name_to_indices = {self.channel_name(g, c): (g, c)
+                                 for g in range(self.no_channel_groups())
+                                 for c in range(self.no_channels(g))}
 
     def _open_tdx(self, tdx_path):
         """Open a TDX file.
@@ -359,10 +364,16 @@ class OpenFile(object):
 
         if isinstance(channel_group, int):
             channel_dict = {}
+            name_doublets = set()
             for i in range(self.no_channels(channel_group)):
                 name = self.channel_name(channel_group, i)
                 ch = self.channel(channel_group, i)
+                if name in channel_dict:
+                    name_doublets.add(name)
                 channel_dict[name] = np.array(ch)
+            if len(name_doublets) > 0:
+                warnings.warn("Duplicate channel name(s): {}" \
+                              .format(name_doublets))
             return channel_dict
         elif isinstance(channel_group, str):
             chg_ind = self.channel_group_index(channel_group, occurrence)
@@ -489,11 +500,11 @@ class OpenFile(object):
             else:
                 raise TypeError(channel)
         elif isinstance(key, str):
-            if key in self.channel_names:
-                _, channel_group, channel = self.channel_search(key)[0]
-                return self.channel(channel_group, channel)
-            else:
-                raise KeyError(key)
+            channel_group, channel = self._name_to_indices[key]
+            if self.channel_names.count(key) > 1:
+                warnings.warn("More than one channel with the name '{}'." \
+                              .format(key))
+            return self.channel(channel_group, channel)
         else:
             return self[0, key]  # Use channel_group 0
 
@@ -657,7 +668,9 @@ class ReadTDM(object):
             except KeyError:
                 raise TypeError(
                             'Unknown data type in TDM file. Channel ' + str(i))
-            chan.name = str(channel_names[i].find('name').text)
+            chan.name = channel_names[i].find('name').text
+            if chan.name is None:
+                chan.name = ''
             self.channels.append(chan)
             formats.append(chan.dtype)
             names.append(chan.name)


### PR DESCRIPTION
Warnings are issued if there are douplicate channel names when accessing with data_file[channel_name] or when calling channel_dict().
For example, try the test file with data_file[''] and data_file.channel_dict(1).

The change at line 660 is so that data_file.channel_names and data_file.channel_name(g, c) give the same names. Before data_file.channel_names had 'None' for missing channel names, now it's ''.

The change in __getitem__ is to make data_file[''] work. Now I use the dict _name_to_indices instead of channel_search() to map from channel name to group and channel inidices.