### PR TITLE
Enhanced compatibility to DIAdem 2020 and  representation types raw_linear and implicit_linear

### DIFF
--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -23,12 +23,13 @@ Search for a column name.  A list of all column names that contain
 
     data_file.channel_search(search_term)
 """
-import os.path
-#import os
+#import os.path
+import os
 import io
 import zipfile
 import re
-import xml.etree.ElementTree as ElementTree
+#import xml.etree.ElementTree as ElementTree
+from xml.etree import ElementTree
 import warnings
 
 import numpy as np
@@ -86,7 +87,7 @@ class OpenFile(object):
         else:
             file = open(tdm_path, 'r')
 
-        self._root = ElementTree.parse(tdm_path).getroot()
+        self._root = ElementTree.parse(file).getroot()
         self._namespace = {'usi': self._root.tag.split('}')[0].strip('{')}
 
         self._xml_tdm_root = self._root.find('.//tdm_root')

--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -24,6 +24,9 @@ Search for a column name.  A list of all column names that contain
     data_file.channel_search(search_term)
 """
 import os.path
+#import os
+import io
+import zipfile
 import re
 import xml.etree.ElementTree as ElementTree
 import warnings
@@ -70,8 +73,18 @@ class OpenFile(object):
         filename specified in the .TDM file will be used.
     """
 
+
     def __init__(self, tdm_path, tdx_path='', encoding='utf-8'):
         self._folder, self._tdm_filename = os.path.split(tdm_path)
+        
+        ## Handle zip-file
+        if zipfile.is_zipfile(tdm_path):
+            zip = zipfile.ZipFile(tdm_path)
+            assert len(zip.namelist()) == 1
+            file = zip.open(zip.namelist()[0]).read().decode('UTF-8')
+            file = io.StringIO(file)
+        else:
+            file = open(tdm_path, 'r')
 
         self._root = ElementTree.parse(tdm_path).getroot()
         self._namespace = {'usi': self._root.tag.split('}')[0].strip('{')}
@@ -93,6 +106,8 @@ class OpenFile(object):
             self._tdx_path = os.path.join(self._folder, self._root.find('.//file').get('url'))
         else:
             self._tdx_path = tdx_path
+
+
 
     def _channel_xml(self, channel_group, channel, occurrence=0, ch_occurrence=0):
         chs = self._channels_xml(channel_group, occurrence)

--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -246,6 +246,8 @@ class OpenFile(object):
 
         # ToDo: Support for implicit linear data
         # if repr == 'implicit_linear':
+        # if repr == 'explicit':
+        # if repr == 'raw_linear':
 
         return data
 


### PR DESCRIPTION
This fork now contains the fixes described in #22 and #23.

### #22
tdm / tdx files made using DIAdem 2020 version will be able to be accessed.

### #23
Also, time channels stored implicitly as some kind of linspaces now are interpreted correctly.

Beyond that, an issue i often had with unprocessed measurement data is fixed: 
When trying to read these i got an error.
In the past we used to fix that by multiplying the whole channel by 1.0 in DIAdem.
Now, that annoying workaround is no longer necessary since they also can be accessed by tdm_loader directly.

### I forgot about one point:
The original tdm_loader returned the channel data as _rec array_. Now, a _np array_ will be returned.
I must confess, I yet don't know exactly what that means and where the difference lies.
I'm also not sure if this may cause some issues if your script expects _rec arrays_ when using _tdm_loader_ 

I think I'll take that into account one day, I dont expect that to be very difficult.

But anyway, so far this fork works fine for my purposes.



