### PR TITLE
Fix channel to add offset in case of implicit_linear seqrep

### DIFF
--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -321,7 +321,8 @@ class OpenFile:
         elif seqrep == "implicit_linear":
             # for time channels. contins two float values
             # for building time scale (constant step width)
-            column = np.array(range(0, nrows)) * data_block[-1]
+            offset = data_block[0]
+            column = np.array(range(0, nrows)) * data_block[-1] + offset 
         elif seqrep == "raw_linear":
             # mapped to proprtional integer scale. needs to be re-scaled to actual values
             offset, slope = np.asarray(


### PR DESCRIPTION
Motivation: Time channels of my tdm files do not start from 0.
The channel function does not consider offset in case of implicit linear sequence representation.
I fix it to add offset (data_block[0]), and I checked it worked with my files.