### PR TITLE
Refactor channel_group_search implementation in tdm_loader

### DIFF
--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -204,7 +204,7 @@ class OpenFile:
                i = self.channel_group_index(name, occurence)
                ind.append((name, i))
 
-        return ind
+        return set(ind)
 
     def channel_search(self, search_term):
         """Returns a list of channel names that contain ``search term``.

--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -204,8 +204,9 @@ class OpenFile:
 
         ind = []
         for name in found_terms:
-            i = self.channel_group_index(name[0], name[1])
-            ind.append((name[0], i))
+            for occurence in range(found_terms.count(name)):
+               i = self.channel_group_index(name, occurence)
+               ind.append((name, i))
 
         return ind
 

--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -189,17 +189,13 @@ class OpenFile:
         chg_names = []
         for x in self._root.findall(".//tdm_channelgroup/name"):
             if x.text is not None:
-                if x.text not in group_names:
-                    group_names[x.text] = 0
-                else:
-                    group_names[x.text] += 1
-                chg_names.append((f"{x.text}", group_names[x.text]))
+                chg_names.append(x.text)
 
         search_term = search_term.upper().replace(" ", "")
         found_terms = [
             name
             for name in chg_names
-            if name[0].upper().replace(" ", "").find(search_term) >= 0
+            if name.upper().replace(" ", "").find(search_term) >= 0
         ]
 
         ind = []

--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -185,22 +185,27 @@ class OpenFile:
         if not isinstance(search_term, str):
             raise TypeError("I can search for str terms only.")
 
-        chg_names = [
-            x.text
-            for x in self._root.findall(".//tdm_channelgroup/name")
-            if x.text is not None
-        ]
+        group_names = {}
+        chg_names = []
+        for x in self._root.findall(".//tdm_channelgroup/name"):
+            if x.text is not None:
+                if x.text not in group_names:
+                    group_names[x.text] = 0
+                else:
+                    group_names[x.text] += 1
+                chg_names.append((f"{x.text}", group_names[x.text]))
+
         search_term = search_term.upper().replace(" ", "")
         found_terms = [
             name
             for name in chg_names
-            if name.upper().replace(" ", "").find(search_term) >= 0
+            if name[0].upper().replace(" ", "").find(search_term) >= 0
         ]
 
         ind = []
         for name in found_terms:
-            i = chg_names.index(name)
-            ind.append((name, i))
+            i = self.channel_group_index(name[0], name[1])
+            ind.append((name[0], i))
 
         return ind
 

--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -199,12 +199,15 @@ class OpenFile:
         ]
 
         ind = []
+        occurences = {}
         for name in found_terms:
-            for occurence in range(found_terms.count(name)):
-               i = self.channel_group_index(name, occurence)
-               ind.append((name, i))
+            if name not in occurences:
+                occurences[name] = True
+                for occurence in range(found_terms.count(name)):
+                   i = self.channel_group_index(name, occurence)
+                   ind.append((name, i))
 
-        return set(ind)
+        return ind
 
     def channel_search(self, search_term):
         """Returns a list of channel names that contain ``search term``.

--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -201,11 +201,10 @@ class OpenFile:
         ind = []
         occurences = {}
         for name in found_terms:
-            if name not in occurences:
-                occurences[name] = True
-                for occurence in range(found_terms.count(name)):
-                   i = self.channel_group_index(name, occurence)
-                   ind.append((name, i))
+            for occurence in range(found_terms.count(name)):
+                i = self.channel_group_index(name, occurence)
+                if (name, i) not in ind:
+                    ind.append((name, i))
 
         return ind
 

--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -190,7 +190,6 @@ class OpenFile:
             for x in self._root.findall(".//tdm_channelgroup/name")
             if x.text is not None
         ]
-
         search_term = search_term.upper().replace(" ", "")
         found_terms = [
             name

--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -185,11 +185,11 @@ class OpenFile:
         if not isinstance(search_term, str):
             raise TypeError("I can search for str terms only.")
 
-        group_names = {}
-        chg_names = []
-        for x in self._root.findall(".//tdm_channelgroup/name"):
-            if x.text is not None:
-                chg_names.append(x.text)
+        chg_names = [
+            x.text
+            for x in self._root.findall(".//tdm_channelgroup/name")
+            if x.text is not None
+        ]
 
         search_term = search_term.upper().replace(" ", "")
         found_terms = [

--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -199,7 +199,6 @@ class OpenFile:
         ]
 
         ind = []
-        occurences = {}
         for name in found_terms:
             for occurence in range(found_terms.count(name)):
                 i = self.channel_group_index(name, occurence)


### PR DESCRIPTION
When searching and resulting groups has identical channel group names, only the first channel group index is returned

New logic will look at channel group names together with occurrences to find the correct channel group index.