### PR TITLE
Refactor channel search functionality in `tdm_loader`

### DIFF
--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -242,7 +242,7 @@ class OpenFile:
             if channel_name:
                 group_uri = re.findall(r'id\("(.+?)"\)', channel.find("group").text)
                 group_id = channel_group_ids.get(group_uri[0])
-                channels = self.get_channels(group_id)
+                channels = self._get_channels(group_id)
 
                 channel_id = channels.get(channel.get("id"))
 

--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -229,7 +229,6 @@ class OpenFile:
         search_term = str(search_term).upper().replace(" ", "")
 
         matched_channels = []
-        channel_groups_cache = {}
         channel_group_ids = {v: i for i, v in enumerate(x.get("id") for x in self._xml_chgs)}
 
         for channel in self._root.findall(".//tdm_channel"):

--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -240,7 +240,7 @@ class OpenFile:
                 group_id = channel_group_ids.get(group_uri[0])
                 channels = get_channels(group_id)
 
-                channel_id = channels.get(channel_id)
+                channel_id = channels.get(channel.get("id"))
 
                 if channel_name.upper().replace(" ", "").find(search_term) >= 0:
                     matched_channels.append((channel_name, group_id, channel_id))

--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -233,7 +233,8 @@ class OpenFile:
         channel_group_ids = {v: i for i, v in enumerate(x.get("id") for x in self._xml_chgs)}
 
         for channel in self._root.findall(".//tdm_channel"):
-            if channel_name := channel.find("name").text:
+            channel_name = channel.find("name").text
+            if channel_name:
                 channel_id = channel.get("id")
                 group_uri = re.findall(r'id\("(.+?)"\)', channel.find("group").text)
                 group_id = channel_group_ids.get(group_uri[0])

--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -238,7 +238,7 @@ class OpenFile:
                 channel_id = channel.get("id")
                 group_uri = re.findall(r'id\("(.+?)"\)', channel.find("group").text)
                 group_id = channel_group_ids.get(group_uri[0])
-                channels = channel_groups_cache.get(group_id)
+                channels = get_channels(group_id)
 
                 if not channels:
                     group = self._xml_chgs[group_id]

--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -170,7 +170,7 @@ class OpenFile:
         return re.findall(r'id\("(.+?)"\)', txt)
 
     @cache
-    def get_channels(self, group_id):
+    def _get_channels(self, group_id):
         group = self._xml_chgs[group_id]
         return {v: i for i, v in enumerate(re.findall(r'id\("(.+?)"\)', group.find("channels").text))}
 

--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -235,7 +235,6 @@ class OpenFile:
         for channel in self._root.findall(".//tdm_channel"):
             channel_name = channel.find("name").text
             if channel_name:
-                channel_id = channel.get("id")
                 group_uri = re.findall(r'id\("(.+?)"\)', channel.find("group").text)
                 group_id = channel_group_ids.get(group_uri[0])
                 channels = get_channels(group_id)

--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -26,6 +26,7 @@ Search for a column name.  A list of all column names that contain
 import os
 import zipfile
 import re
+from functools import cache
 
 from xml.etree import ElementTree
 import warnings
@@ -168,6 +169,11 @@ class OpenFile:
             return []
         return re.findall(r'id\("(.+?)"\)', txt)
 
+    @cache
+    def get_channels(self, group_id):
+        group = self._xml_chgs[group_id]
+        return {v: i for i, v in enumerate(re.findall(r'id\("(.+?)"\)', group.find("channels").text))}
+
     def channel_group_search(self, search_term):
         """Returns a list of channel group names that contain ``search term``.
         Results are independent of case and spaces in the channel name.
@@ -236,7 +242,7 @@ class OpenFile:
             if channel_name:
                 group_uri = re.findall(r'id\("(.+?)"\)', channel.find("group").text)
                 group_id = channel_group_ids.get(group_uri[0])
-                channels = get_channels(group_id)
+                channels = self.get_channels(group_id)
 
                 channel_id = channels.get(channel.get("id"))
 

--- a/tdm_loader/tdm_loader.py
+++ b/tdm_loader/tdm_loader.py
@@ -240,10 +240,6 @@ class OpenFile:
                 group_id = channel_group_ids.get(group_uri[0])
                 channels = get_channels(group_id)
 
-                if not channels:
-                    group = self._xml_chgs[group_id]
-                    channels = {v: i for i, v in enumerate(re.findall(r'id\("(.+?)"\)', group.find("channels").text))}
-                    channel_groups_cache[group_id] = channels
                 channel_id = channels.get(channel_id)
 
                 if channel_name.upper().replace(" ", "").find(search_term) >= 0:

--- a/tdm_loader/tests/test_non_zip_tdm.py
+++ b/tdm_loader/tests/test_non_zip_tdm.py
@@ -204,7 +204,9 @@ def test_channel_search(tdm_file):
         ("Float as Float", 0, 1),
     ]
 
-    assert tdm_file.channel_search("") == []
+    assert tdm_file.channel_search("") == [('Float_4_Integers', 0, 0),
+                                           ('Float as Float', 0, 1),
+                                           ('Integer32_with_max_min', 0, 2)]
 
 
 # pylint: disable=redefined-outer-name


### PR DESCRIPTION
The previous implementation of the channel search function in the `tdm_loader.py` was refactored. Search now matches channels directly without set generation and updates retrieval with more efficient lookups. The modification updates the testing to reflect the changes in the returned search results as well.

Before the refactor searching throe 22000 channels took 6.5min and after it took 0.08s

Also the test has changed to be similar to group_search when searching for "", all channels should be returned.